### PR TITLE
keep pixel type the same when extracting labels

### DIFF
--- a/slicerio/segmentation.py
+++ b/slicerio/segmentation.py
@@ -84,7 +84,7 @@ def extract_segments(voxels, header, segmentation_info, segment_names_to_label_v
     import re
 
     # Create empty array from last 3 dimensions (output will be flattened to a 3D array)
-    output_voxels = np.zeros(voxels.shape[-3:])
+    output_voxels = np.zeros(voxels.shape[-3:], dtype=voxels.dtype)
 
     # Copy non-segmentation fields to the extracted header
     output_header = {}

--- a/slicerio/tests/test_segmentation.py
+++ b/slicerio/tests/test_segmentation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import nrrd
 import slicerio
 import unittest
 
@@ -54,6 +55,15 @@ class TestSegmentationRoundtrip(unittest.TestCase):
         self.assertEqual('anatomicRegion' in terminology, False)
         self.assertEqual('anatomicRegionModifier' in terminology, False)
 
+    def test_segmentation_pixel_type(self):
+        input_segmentation_filepath = slicerio.get_testdata_file('Segmentation.seg.nrrd')
+        voxels, header = nrrd.read(input_segmentation_filepath)
+        segmentation_info = slicerio.read_segmentation_info(input_segmentation_filepath)
+        extracted_voxels, extracted_header = slicerio.extract_segments(
+            voxels, header, segmentation_info, [('ribs', 1), ('right lung', 2)]
+        )
+
+        self.assertEqual(extracted_voxels.dtype, voxels.dtype)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Extracted voxels should be the same type as the original array.

The function was extracting them to float, when it created the new array with `np.zeros` without specifying a  dtype